### PR TITLE
ci: update shared Java workflows

### DIFF
--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     with:
       semver_strategy: snapshot
       upstream_repository: nats-io/nats-streaming-server
@@ -42,7 +42,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -58,4 +58,4 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@dd9103b07347af0bb02d5f6207c00af473c603b1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,6 +27,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,6 +20,6 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     with:
       force: ${{ inputs.force }}
       semver_strategy: snapshot
@@ -42,7 +42,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -58,7 +58,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
 
   github:
     needs:
@@ -69,7 +69,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@964f0f19a402a2e5dc2f04df5524ecc2f4f88326
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@dd9103b07347af0bb02d5f6207c00af473c603b1
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Pins the Central Maven token-scope correction for a clean snapshot retest.